### PR TITLE
Add configuration options for navigation badges

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -70,6 +70,10 @@ trait Configuration
      */
     protected Closure | string | null $domain = null;
 
+    protected Closure | bool $showNavigationBadges = true;
+
+    protected array $showNavigationBadgesArray = [];
+
     /*
      * @deprecated deprecated since version 2.1
      */

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -3,6 +3,7 @@
 namespace LaraZeus\Bolt;
 
 use Closure;
+use LaraZeus\Bolt\Enums\Resources;
 
 trait Configuration
 {
@@ -231,5 +232,40 @@ trait Configuration
     public function getHiddenResources(): ?array
     {
         return $this->hideResources;
+    }
+
+    public function hideNavigationBadges(Closure|bool $show = false, ?Resources $resource = null): static
+    {
+        return $this->setShowNavigationBadges($show, $resource);
+    }
+
+    public function showNavigationBadges(Closure|bool $show = true, ?Resources $resource = null): static
+    {
+        return $this->setShowNavigationBadges($show, $resource);
+    }
+
+    private function setShowNavigationBadges(Closure|bool $show = true, ?Resources $resource = null): static
+    {
+        if (!is_null($resource)) {
+            $this->showNavigationBadgesArray[$resource->value] = $show;
+        } else {
+            $this->showNavigationBadges = $show;
+        }
+
+        return $this;
+    }
+
+    public function getShowNavigationBadges(?Resources $resource = null): bool
+    {
+        if (!is_null($resource)) {
+            return $this->showNavigationBadgesArray[$resource->value] ?? $this->evaluate($this->showNavigationBadges);
+        }
+
+        return $this->evaluate($this->showNavigationBadges);
+    }
+
+    public static function getShowOrHideNavigationBadges(?Resources $resource = null): bool
+    {
+        return (new static())::get()->getShowNavigationBadges($resource);
     }
 }

--- a/src/Enums/Resources.php
+++ b/src/Enums/Resources.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace LaraZeus\Bolt\Enums;
+
+enum Resources: string
+{
+    case CategoryResource = 'CategoryResource';
+    case CollectionResource = 'CollectionResource';
+    case FormResource = 'FormResource';
+}

--- a/src/Filament/Resources/CategoryResource.php
+++ b/src/Filament/Resources/CategoryResource.php
@@ -27,6 +27,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Str;
 use LaraZeus\Bolt\BoltPlugin;
+use LaraZeus\Bolt\Enums\Resources;
 use LaraZeus\Bolt\Filament\Resources\CategoryResource\Pages\CreateCategory;
 use LaraZeus\Bolt\Filament\Resources\CategoryResource\Pages\EditCategory;
 use LaraZeus\Bolt\Filament\Resources\CategoryResource\Pages\ListCategories;
@@ -47,7 +48,11 @@ class CategoryResource extends BoltResource
 
     public static function getNavigationBadge(): ?string
     {
-        return (string) BoltPlugin::getModel('Category')::query()->count();
+        if (!BoltPlugin::getShowOrHideNavigationBadges(Resources::CategoryResource)) {
+            return null;
+        }
+
+        return (string)BoltPlugin::getModel('Category')::query()->count();
     }
 
     public static function getGloballySearchableAttributes(): array

--- a/src/Filament/Resources/CollectionResource.php
+++ b/src/Filament/Resources/CollectionResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 use LaraZeus\Bolt\BoltPlugin;
+use LaraZeus\Bolt\Enums\Resources;
 use LaraZeus\Bolt\Filament\Resources\CollectionResource\Pages;
 use LaraZeus\Bolt\Filament\Resources\CollectionResource\Widgets\EditCollectionWarning;
 
@@ -32,7 +33,11 @@ class CollectionResource extends BoltResource
 
     public static function getNavigationBadge(): ?string
     {
-        return (string) BoltPlugin::getModel('Collection')::query()->count();
+        if (!BoltPlugin::getShowOrHideNavigationBadges(Resources::CollectionResource)) {
+            return null;
+        }
+
+        return (string)BoltPlugin::getModel('Collection')::query()->count();
     }
 
     public static function getGloballySearchableAttributes(): array

--- a/src/Filament/Resources/FormResource.php
+++ b/src/Filament/Resources/FormResource.php
@@ -31,6 +31,7 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 use LaraZeus\Bolt\BoltPlugin;
 use LaraZeus\Bolt\Concerns\HasOptions;
 use LaraZeus\Bolt\Concerns\Schemata;
+use LaraZeus\Bolt\Enums\Resources;
 use LaraZeus\Bolt\Filament\Actions\ReplicateFormAction;
 use LaraZeus\Bolt\Filament\Resources\FormResource\Pages;
 use LaraZeus\Bolt\Models\Form as ZeusForm;
@@ -57,7 +58,11 @@ class FormResource extends BoltResource
 
     public static function getNavigationBadge(): ?string
     {
-        return (string) BoltPlugin::getModel('Form')::query()->count();
+        if (!BoltPlugin::getShowOrHideNavigationBadges(Resources::FormResource)) {
+            return null;
+        }
+
+        return (string)BoltPlugin::getModel('Form')::query()->count();
     }
 
     public static function getGloballySearchableAttributes(): array


### PR DESCRIPTION
To start off, just like you mentioned in Discord, naming variables isn't my strongest suit.

This adds a configuration option for the navigation badges.
I created an Enum so people will be able to disable the navigation badges for specific resources if desired instead of just all of them.

Some examples:

This will hide all navigation badges
```
BoltPlugin::make()
    ->hideNavigationBadges()
```

This will show all navigation badges (default)
```
BoltPlugin::make()
    ->showNavigationBadges()
```

This will hide only the CollectionResource navigation badge
```
BoltPlugin::make()
    ->hideNavigationBadges(resource: LaraZeus\Bolt\Resources::CollectionResource)
```

This will show only the FormResource navigation badge
```
BoltPlugin::make()
    ->hideNavigationBadges()
    ->showNavigationBadges(resource: LaraZeus\Bolt\Resources::CollectionResource)
```

If you have any questions or want anything changed just let me know!