### PR TITLE
Update fill-forms.blade.php

### DIFF
--- a/resources/views/themes/zeus/bolt/fill-forms.blade.php
+++ b/resources/views/themes/zeus/bolt/fill-forms.blade.php
@@ -83,7 +83,7 @@
     @if($sent)
         @include($boltTheme.'.submitted')
     @else
-        <x-filament-panels::form wire:submit.prevent="store" class="@if(!$inline) mx-2 @endif">
+        <x-filament-panels::form wire:submit.prevent="store" :class="!$inline ? 'mx-2' : ''">
             @if(!$inline)
                 {{ \LaraZeus\Bolt\Facades\Bolt::renderHookBlade('zeus-form.before') }}
             @endif


### PR DESCRIPTION
fix livewire max execution time issue
you cannot write `@if` blocks in livewire. In some version of the livewire it causes max execution timeout. This is the proper way to solve that issue if you want you can merge it or at least this is an information for future ones 🚀 