### PR TITLE
Support for  downloading File Uploads to Private Filedisks

### DIFF
--- a/config/zeus-bolt.php
+++ b/config/zeus-bolt.php
@@ -55,7 +55,7 @@ return [
 
     'uploadDisk' => env('BOLT_FILESYSTEM_DISK', 'public'),
 
-    'uploadDirectory' => env('BOLT_FILESYSTEM_PREFIX', 'forms'),
+    'uploadDirectory' => env('BOLT_FILESYSTEM_DIRECTORY', 'forms'),
 
     'uploadVisibility' => env('BOLT_FILESYSTEM_VISIBILITY', 'public'),
 

--- a/config/zeus-bolt.php
+++ b/config/zeus-bolt.php
@@ -53,11 +53,11 @@ return [
 
     'defaultMailable' => \LaraZeus\Bolt\Mail\FormSubmission::class,
 
-    'uploadDisk' => 'public',
+    'uploadDisk' => env('BOLT_FILESYSTEM_DISK', 'public'),
 
-    'uploadDirectory' => 'forms',
+    'uploadDirectory' => env('BOLT_FILESYSTEM_PREFIX', 'forms'),
 
-    'uploadVisibility' => 'public',
+    'uploadVisibility' => env('BOLT_FILESYSTEM_VISIBILITY', 'public'),
 
     'show_presets' => false,
 

--- a/resources/views/filament/fields/file-upload.blade.php
+++ b/resources/views/filament/fields/file-upload.blade.php
@@ -6,11 +6,7 @@
                         target="_blank"
                         size="sm"
                         outlined
-                        @if(config('zeus-bolt.uploadVisibility') === 'private')
-                            href="{{ $disk->temporaryUrl($file, now()->addMinute()) }}"
-                        @else
-                            href="{{ $disk->url($file) }}"
-                        @endif
+                        href="{{ $getUrl($file) }}"
                 >
                         {{ __('view file') .': '. $loop->iteration }}
                 </x-filament::link>

--- a/resources/views/filament/fields/file-upload.blade.php
+++ b/resources/views/filament/fields/file-upload.blade.php
@@ -6,7 +6,11 @@
                         target="_blank"
                         size="sm"
                         outlined
-                        href="{{ Storage::disk(config('zeus-bolt.uploadDisk'))->url($file) }}"
+                        @if(config('zeus-bolt.uploadVisibility') === 'private')
+                            href="{{ $disk->temporaryUrl($file, now()->addMinute()) }}"
+                        @else
+                            href="{{ $disk->url($file) }}"
+                        @endif
                 >
                         {{ __('view file') .': '. $loop->iteration }}
                 </x-filament::link>

--- a/src/Fields/Classes/FileUpload.php
+++ b/src/Fields/Classes/FileUpload.php
@@ -69,13 +69,18 @@ class FileUpload extends FieldsContract
     public function getResponse(Field $field, FieldResponse $resp): string
     {
         $responseValue = filled($resp->response) ? Bolt::isJson($resp->response) ? json_decode($resp->response) : [$resp->response] : [];
+
         $disk = Storage::disk(config('zeus-bolt.uploadDisk'));
+
+        $getUrl = fn($file) => config('zeus-bolt.uploadVisibility') === 'private'
+            ? $disk->temporaryUrl($file, now()->addMinute())
+            : $disk->url($file);
 
         return view('zeus::filament.fields.file-upload')
             ->with('resp', $resp)
             ->with('responseValue', $responseValue)
             ->with('field', $field)
-            ->with('disk', $disk)
+            ->with('getUrl', $getUrl)
             ->render();
     }
 

--- a/src/Fields/Classes/FileUpload.php
+++ b/src/Fields/Classes/FileUpload.php
@@ -3,6 +3,7 @@
 namespace LaraZeus\Bolt\Fields\Classes;
 
 use Filament\Forms\Components\Hidden;
+use Illuminate\Support\Facades\Storage;
 use LaraZeus\Accordion\Forms\Accordion;
 use LaraZeus\Accordion\Forms\Accordions;
 use LaraZeus\Bolt\Facades\Bolt;
@@ -68,11 +69,13 @@ class FileUpload extends FieldsContract
     public function getResponse(Field $field, FieldResponse $resp): string
     {
         $responseValue = filled($resp->response) ? Bolt::isJson($resp->response) ? json_decode($resp->response) : [$resp->response] : [];
+        $disk = Storage::disk(config('zeus-bolt.uploadDisk'));
 
         return view('zeus::filament.fields.file-upload')
             ->with('resp', $resp)
             ->with('responseValue', $responseValue)
             ->with('field', $field)
+            ->with('disk', $disk)
             ->render();
     }
 

--- a/src/Fields/Classes/FileUpload.php
+++ b/src/Fields/Classes/FileUpload.php
@@ -73,7 +73,7 @@ class FileUpload extends FieldsContract
         $disk = Storage::disk(config('zeus-bolt.uploadDisk'));
 
         $getUrl = fn($file) => config('zeus-bolt.uploadVisibility') === 'private'
-            ? $disk->temporaryUrl($file, now()->addMinute())
+            ? $disk->temporaryUrl($file, now()->addDay())
             : $disk->url($file);
 
         return view('zeus::filament.fields.file-upload')


### PR DESCRIPTION
File uploads in Bolt are broken when attempting to view if you use a private filesystem. This is because it does not generate a temporary URL. This PR resolves that by using a closure to generate the URL, and checking whether the currently configured disk is public or private.

Additionally, I've added 3 new environment variables (with default values matching original config):
- `BOLT_FILESYSTEM_DISK`
- `BOLT_FILESYSTEM_PREFIX`
- `BOLT_FILESYSTEM_VISIBILITY`
