### PR TITLE
Fix issue with inline not working on Toggle

### DIFF
--- a/src/Fields/Classes/Toggle.php
+++ b/src/Fields/Classes/Toggle.php
@@ -126,7 +126,7 @@ class Toggle extends FieldsContract
             $component = $component->offColor(Color::hex($zeusField->options['off-color']));
         }
 
-        if (optional($zeusField->options)['is-inline']) {
+        if (isset($zeusField->options['is-inline'])) {
             $component = $component->inline($zeusField->options['is-inline']);
         }
 


### PR DESCRIPTION
The Toggle field is passed an `is-inline` option. `is-inline` is a boolean. `optional()` ignores `null|false` and therefore the Toggle can never be set as not inline i.e. `->inline(false)`

This fix addresses that error.