### PR TITLE
Fix issue with cloning form fields

### DIFF
--- a/src/Concerns/Schemata.php
+++ b/src/Concerns/Schemata.php
@@ -368,9 +368,9 @@ trait Schemata
                 ->cloneable()
                 ->minItems(1)
 
-                ->cloneAction(fn (Action $action) => $action->action(function (Component $component) {
+                ->cloneAction(fn(Action $action) => $action->action(function (Component $component, $arguments) {
                     $items = $component->getState();
-                    $originalItem = end($items);
+                    $originalItem = $items[$arguments['item']];
                     $clonedItem = array_merge($originalItem, [
                         'name' => $originalItem['name'] . ' new',
                         'options' => [


### PR DESCRIPTION
When creating a form with multiple form fields - there is an action to clone the field. Regardless of which field is cloned, it always clones the last field in the list rather than the one that was clicked. This PR fixes that. 