### PR TITLE
Fix conditional visibility when relying on a toggle field being false

### DIFF
--- a/src/Fields/FieldsContract.php
+++ b/src/Fields/FieldsContract.php
@@ -138,6 +138,11 @@ abstract class FieldsContract implements Arrayable, Fields
                 }
 
                 $relatedFieldArray = Arr::wrap($get('zeusData.' . $relatedField));
+
+                // In the example where a field is only visible when the related field is NOT checked, 
+                // we need to convert booleans to strings for in_array comparison
+                $relatedFieldArray = array_map(fn($value) => is_bool($value) ? ($value ? 'true' : 'false') : $value, $relatedFieldArray);
+                
                 if (in_array($relatedFieldValues, $relatedFieldArray)) {
                     return true;
                 }


### PR DESCRIPTION
Scenario:

Field A: Toggle Field
Field B: Text Field with conditional visibility when Field A is Not Checked.

With the above scenario the in_array function at line 146 does not return true because we're comparing a string "false" from the database (visibility options) with a boolean false from the related toggle field. 

Converting the boolean fields to strings here solves that issue.