### PR TITLE
When cloning, merge in all the options from the original item

### DIFF
--- a/src/Concerns/Schemata.php
+++ b/src/Concerns/Schemata.php
@@ -373,9 +373,9 @@ trait Schemata
                     $originalItem = end($items);
                     $clonedItem = array_merge($originalItem, [
                         'name' => $originalItem['name'] . ' new',
-                        'options' => [
+                        'options' => array_merge($originalItem['options'], [
                             'htmlId' => $originalItem['options']['htmlId'] . Str::random(2),
-                        ],
+                        ]),
                     ]);
 
                     $items[] = $clonedItem;


### PR DESCRIPTION
When cloning, merge in all the options from the original item - previously it was setting the htmlId and removing everything else