### PR TITLE
Don't use the hint text in the tooltip

### DIFF
--- a/src/Fields/FieldsContract.php
+++ b/src/Fields/FieldsContract.php
@@ -117,7 +117,7 @@ abstract class FieldsContract implements Arrayable, Fields
                 $component = $component->hint($zeusField->options['hint']['text']);
             }
             if (optional($zeusField->options)['hint']['icon']) {
-                $component = $component->hintIcon($zeusField->options['hint']['icon'], tooltip: $zeusField->options['hint']['icon-tooltip'] ?? $zeusField->options['hint']['text']);
+                $component = $component->hintIcon($zeusField->options['hint']['icon'], tooltip: $zeusField->options['hint']['icon-tooltip']);
             }
             if (optional($zeusField->options)['hint']['color']) {
                 $component = $component->hintColor(fn () => Color::hex($zeusField->options['hint']['color']));


### PR DESCRIPTION
Currently, if you add a hint text, the same text also appears in the tooltip (if no tooltip text is set). It doesn't make sense to show the same text twice, so only show the tooltip text if the tooltip text is set.