### PR TITLE
Implement translatable collection. 

### DIFF
--- a/src/Filament/Resources/CollectionResource/Pages/CreateCollection.php
+++ b/src/Filament/Resources/CollectionResource/Pages/CreateCollection.php
@@ -2,10 +2,20 @@
 
 namespace LaraZeus\Bolt\Filament\Resources\CollectionResource\Pages;
 
+use Filament\Actions\LocaleSwitcher;
 use Filament\Resources\Pages\CreateRecord;
 use LaraZeus\Bolt\Filament\Resources\CollectionResource;
 
 class CreateCollection extends CreateRecord
 {
+    use CreateRecord\Concerns\Translatable;
+
     protected static string $resource = CollectionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            LocaleSwitcher::make(),
+        ];
+    }
 }

--- a/src/Filament/Resources/CollectionResource/Pages/EditCollection.php
+++ b/src/Filament/Resources/CollectionResource/Pages/EditCollection.php
@@ -2,18 +2,28 @@
 
 namespace LaraZeus\Bolt\Filament\Resources\CollectionResource\Pages;
 
+use Filament\Actions\LocaleSwitcher;
 use Filament\Resources\Pages\EditRecord;
 use LaraZeus\Bolt\Filament\Resources\CollectionResource;
 use LaraZeus\Bolt\Filament\Resources\CollectionResource\Widgets\EditCollectionWarning;
 
 class EditCollection extends EditRecord
 {
+    use EditRecord\Concerns\Translatable;
+
     protected static string $resource = CollectionResource::class;
 
     protected function getHeaderWidgets(): array
     {
         return [
             EditCollectionWarning::class,
+        ];
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            LocaleSwitcher::make(),
         ];
     }
 }

--- a/src/Filament/Resources/CollectionResource/Pages/ListCollections.php
+++ b/src/Filament/Resources/CollectionResource/Pages/ListCollections.php
@@ -8,12 +8,15 @@ use LaraZeus\Bolt\Filament\Resources\CollectionResource;
 
 class ListCollections extends ListRecords
 {
+    use ListRecords\Concerns\Translatable;
+
     protected static string $resource = CollectionResource::class;
 
     protected function getHeaderActions(): array
     {
         return [
             Actions\CreateAction::make(),
+            Actions\LocaleSwitcher::make(),
         ];
     }
 }

--- a/src/Models/Collection.php
+++ b/src/Models/Collection.php
@@ -56,13 +56,16 @@ class Collection extends Model
      */
     public function getValuesAttribute($value)
     {
+        if($value instanceof \Illuminate\Support\Collection){
+            return $value;
+        }
         if(is_array($value)){
             return collect($value);
         }
         if(is_string($value)){
             return collect(json_encode($value));
         }
-        return $value;
+        return collect($value);
     }
 
     protected static function newFactory(): Factory

--- a/src/Models/Collection.php
+++ b/src/Models/Collection.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use LaraZeus\Bolt\Concerns\HasUpdates;
 use LaraZeus\Bolt\Database\Factories\CollectionFactory;
+use Spatie\Translatable\HasTranslations;
 
 /**
  * @property string $updated_at
@@ -19,12 +20,11 @@ class Collection extends Model
     use HasFactory;
     use HasUpdates;
     use SoftDeletes;
+    use HasTranslations;
 
     protected $guarded = [];
 
-    protected $casts = [
-        'values' => 'collection',
-    ];
+    public $translatable = ['name', 'values'];
 
     public function getTable(): string
     {
@@ -45,6 +45,24 @@ class Collection extends Model
         }
 
         return null;
+    }
+
+    /**
+     * Returns the values as a collection. Translatable variables are always cast as an array. This function transforms
+     * it to a collection.
+     * Note: The newer Attribute approach does not seem to be compatible with laravel-translatable ;-(.
+     * @param $value
+     * @return \Illuminate\Support\Collection
+     */
+    public function getValuesAttribute($value)
+    {
+        if(is_array($value)){
+            return collect($value);
+        }
+        if(is_string($value)){
+            return collect(json_encode($value));
+        }
+        return $value;
     }
 
     protected static function newFactory(): Factory

--- a/src/Models/Collection.php
+++ b/src/Models/Collection.php
@@ -59,6 +59,9 @@ class Collection extends Model
         if($value instanceof \Illuminate\Support\Collection){
             return $value;
         }
+        if(empty($value)){
+            return collect();
+        }
         if(is_array($value)){
             return collect($value);
         }


### PR DESCRIPTION
I implemented the translatable collection.

I had to remove the cast to collection of the `values` column, because laravel-translatable casts all translatable columns to array.

As @atmonshi  mentioned in #359, this feature is not compatible with existing data. I looked a bit at options to fix this via the `booted()` function of a model, but there is no event when data is loaded into the model. One option would be override the `getTranslation()` function on the model, but this is a complicated function, causing this implementation to break in the future.

I think the cleanest way is probably to create a migration script. This should be quite easy and can be done on query level, see https://github.com/spatie/laravel-translatable/issues/111
What do you think?