### PR TITLE
pass the response to the Extensions SubmittedRender

### DIFF
--- a/resources/views/themes/zeus/bolt/submitted.blade.php
+++ b/resources/views/themes/zeus/bolt/submitted.blade.php
@@ -13,7 +13,10 @@
                 </span>
             @endif
 
-            {!! \LaraZeus\Bolt\Facades\Extensions::init($zeusForm, 'SubmittedRender', ['extensionData' => $extensionData['extInfo']['itemId'] ?? 0]) !!}
+                {!! \LaraZeus\Bolt\Facades\Extensions::init($zeusForm, 'SubmittedRender', [
+                    'extensionData' => $extensionData['extInfo']['itemId'] ?? 0,
+                    'response' => $extensionData['response'],
+                ]) !!}
 
         </x-filament::section>
     </div>


### PR DESCRIPTION
now you can access the response on the Extensions `SubmittedRender` hook

note if you're overwriting the view `submitted.blade.php` make sure to update it to last version

this the change:
```php
{!! \LaraZeus\Bolt\Facades\Extensions::init($zeusForm, 'SubmittedRender', [
    'extensionData' => $extensionData['extInfo']['itemId'] ?? 0,
    'response' => $extensionData['response'],
]) !!}
```