### PR TITLE
Hide the open link when using extensions

### DIFF
--- a/src/Filament/Resources/FormResource/Pages/EditForm.php
+++ b/src/Filament/Resources/FormResource/Pages/EditForm.php
@@ -44,6 +44,7 @@ class EditForm extends EditRecord
                 ->tooltip(__('open form'))
                 ->color('warning')
                 ->url(fn () => route(BoltPlugin::get()->getRouteNamePrefix() . 'bolt.form.show', $this->record))
+                ->visible(fn (Form $record) => $record->extensions === null)
                 ->openUrlInNewTab(),
         ];
     }


### PR DESCRIPTION
This removes the form's "open" button from the edit resource page. 

The link is invalid when using an Extension so this commit makes EditForm.php behave in the same way as [FormResource.php](https://github.com/lara-zeus/bolt/blob/d81d7ecf7283133e56bd9262b8bf95bbb4a08fff/src/Filament/Resources/FormResource.php#L101) and [ViewForm.php](https://github.com/lara-zeus/bolt/blob/d81d7ecf7283133e56bd9262b8bf95bbb4a08fff/src/Filament/Resources/FormResource/Pages/ViewForm.php#L43).