### PR TITLE
Support actions on the form page

### DIFF
--- a/src/Livewire/FillForms.php
+++ b/src/Livewire/FillForms.php
@@ -2,6 +2,8 @@
 
 namespace LaraZeus\Bolt\Livewire;
 
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Illuminate\Support\Arr;
@@ -18,8 +20,10 @@ use Throwable;
 /**
  * @property mixed $form
  */
-class FillForms extends Component implements HasForms
+class FillForms extends Component implements HasActions, HasForms
 {
+    use InteractsWithActions;
+
     use InteractsWithForms;
 
     public Form $zeusForm;


### PR DESCRIPTION
Implement the HasActions contract so that actions, specifically repeater fields, can be used on forms.