### PR TITLE
fix: context handling in EditForm field actions

### DIFF
--- a/src/Filament/Resources/FormResource/Pages/EditForm.php
+++ b/src/Filament/Resources/FormResource/Pages/EditForm.php
@@ -60,7 +60,13 @@ class EditForm extends EditRecord
 
         foreach ($formSections as $sectionId => $section) {
             foreach ($section['fields'] as $fieldId => $field) {
-                $this->mountAction('fields options', ['item' => $fieldId], ['recordKey' => $section['id'], 'schemaComponent' => "form.sections.$sectionId.fields"]);
+                $context = ['schemaComponent' => "form.sections.$sectionId.fields"];
+
+                if (array_key_exists('id', $section)) {
+                    $context['recordKey'] = $section['id'];
+                }
+
+                $this->mountAction('fields options', ['item' => $fieldId], context: $context);
                 $this->callMountedAction();
                 $this->unmountAction();
             }


### PR DESCRIPTION
Updated the context passed to mountAction for field options to only include 'recordKey' if the section has an 'id' key. This prevents potential errors when a new section is created in the EditForm page.
