### PR TITLE
Fix order of field options validation

### DIFF
--- a/src/Filament/Resources/FormResource/Pages/CreateForm.php
+++ b/src/Filament/Resources/FormResource/Pages/CreateForm.php
@@ -30,7 +30,7 @@ class CreateForm extends CreateRecord
     /**
      * @throws Throwable
      */
-    protected function beforeValidate(): void
+    protected function afterValidate(): void
     {
         $formSections = $this->form->getComponent('sections')->getState();
 

--- a/src/Filament/Resources/FormResource/Pages/EditForm.php
+++ b/src/Filament/Resources/FormResource/Pages/EditForm.php
@@ -54,7 +54,7 @@ class EditForm extends EditRecord
     /**
      * @throws Throwable
      */
-    protected function beforeValidate(): void
+    protected function afterValidate(): void
     {
         $formSections = $this->form->getComponent('sections')->getState();
 


### PR DESCRIPTION
Renamed the beforeValidate method to afterValidate in both CreateForm and EditForm pages to reflect the correct validation lifecycle hook.