### PR TITLE
Solve #413 (Make available fields overridable)

### DIFF
--- a/src/BoltServiceProvider.php
+++ b/src/BoltServiceProvider.php
@@ -10,6 +10,7 @@ use LaraZeus\Bolt\Commands\ZeusFieldCommand;
 use LaraZeus\Bolt\Livewire\FillForms;
 use LaraZeus\Bolt\Livewire\ListEntries;
 use LaraZeus\Bolt\Livewire\ListForms;
+use LaraZeus\Bolt\Services\BoltService;
 use LaraZeus\Core\CoreServiceProvider;
 use Livewire\Livewire;
 use Spatie\LaravelPackageTools\Package;
@@ -38,6 +39,15 @@ class BoltServiceProvider extends PackageServiceProvider
         Livewire::component('bolt.fill-form', FillForms::class);
         Livewire::component('bolt.list-forms', ListForms::class);
         Livewire::component('bolt.list-entries', ListEntries::class);
+    }
+
+    public function register()
+    {
+        $this->app->singleton('bolt', function ($app) {
+            return new BoltService();
+        });
+
+        return parent::register();
     }
 
     /**

--- a/src/Facades/Bolt.php
+++ b/src/Facades/Bolt.php
@@ -24,41 +24,6 @@ class Bolt extends Facade
         return 'bolt';
     }
 
-    public static function availableFields(): Collection
-    {
-        if (app()->isLocal()) {
-            Cache::forget('bolt.fields');
-        }
-
-        return Cache::remember('bolt.fields', Carbon::parse('1 month'), function () {
-            $coreFields = Collectors::collectClasses(__DIR__ . '/../Fields/Classes', 'LaraZeus\\Bolt\\Fields\\Classes\\');
-            $appFields = Collectors::collectClasses(base_path(config('zeus-bolt.collectors.fields.path')), config('zeus-bolt.collectors.fields.namespace'));
-
-            $fields = collect();
-
-            if ($coreFields->isNotEmpty()) {
-                $fields = $fields->merge($coreFields);
-            }
-
-            if ($appFields->isNotEmpty()) {
-                $fields = $fields->merge($appFields);
-            }
-
-            if (static::hasPro()) {
-                $boltProFields = Collectors::collectClasses(
-                    base_path('vendor/lara-zeus/bolt-pro/src/Fields'),
-                    'LaraZeus\\BoltPro\\Fields\\'
-                );
-
-                if ($boltProFields->isNotEmpty()) {
-                    $fields = $fields->merge($boltProFields);
-                }
-            }
-
-            return $fields->sortBy('sort');
-        });
-    }
-
     public static function availableDataSource(): Collection
     {
         if (app()->isLocal()) {

--- a/src/Services/BoltService.php
+++ b/src/Services/BoltService.php
@@ -5,6 +5,7 @@ namespace LaraZeus\Bolt\Services;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use LaraZeus\Bolt\Facades\Bolt;
 use LaraZeus\Bolt\Facades\Collectors;
 
 class BoltService 
@@ -29,7 +30,7 @@ class BoltService
                 $fields = $fields->merge($appFields);
             }
 
-            if (static::hasPro()) {
+            if (Bolt::hasPro()) {
                 $boltProFields = Collectors::collectClasses(
                     base_path('vendor/lara-zeus/bolt-pro/src/Fields'),
                     'LaraZeus\\BoltPro\\Fields\\'

--- a/src/Services/BoltService.php
+++ b/src/Services/BoltService.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace LaraZeus\Bolt\Services;
+
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use LaraZeus\Bolt\Facades\Collectors;
+
+class BoltService 
+{
+    public function availableFields(): Collection 
+    {
+        if (app()->isLocal()) {
+            Cache::forget('bolt.fields');
+        }
+
+        return Cache::remember('bolt.fields', Carbon::parse('1 month'), function () {
+            $coreFields = Collectors::collectClasses(__DIR__ . '/../Fields/Classes', 'LaraZeus\\Bolt\\Fields\\Classes\\');
+            $appFields = Collectors::collectClasses(base_path(config('zeus-bolt.collectors.fields.path')), config('zeus-bolt.collectors.fields.namespace'));
+
+            $fields = collect();
+
+            if ($coreFields->isNotEmpty()) {
+                $fields = $fields->merge($coreFields);
+            }
+
+            if ($appFields->isNotEmpty()) {
+                $fields = $fields->merge($appFields);
+            }
+
+            if (static::hasPro()) {
+                $boltProFields = Collectors::collectClasses(
+                    base_path('vendor/lara-zeus/bolt-pro/src/Fields'),
+                    'LaraZeus\\BoltPro\\Fields\\'
+                );
+
+                if ($boltProFields->isNotEmpty()) {
+                    $fields = $fields->merge($boltProFields);
+                }
+            }
+
+            return $fields->sortBy('sort');
+        });
+    }
+}


### PR DESCRIPTION
Moved `availableFields` into a `BoltService` to allow container resolution.

This allows us to register our own `BoltService` in our app's service provider `boot` and remove some of the fields we don't want - client doesn't need things like ColorPicker or FileUpload for this particular project.

Thanks folks!

```
// AppServiceProvider::boot
$this->app->singleton('bolt', BoltService::class);
```

```
// BoltService.php
class BoltService
{
	public function availableFields(): Collection
	{
		return Collectors::collectClasses(base_path(config('zeus-bolt.collectors.fields.path')), config('zeus-bolt.collectors.fields.namespace'));
	}
}
```

We then fill `App/Zeus/Bolt/Fields` with our own classes that override the selected built in fields that we want.

I'd imagine it would be useful to move the rest of the Facade methods on to the Service - these changes meet our needs for the time being though.