### PR TITLE
Remove afterValidate hooks from form pages

### DIFF
--- a/src/Filament/Resources/FormResource/Pages/CreateForm.php
+++ b/src/Filament/Resources/FormResource/Pages/CreateForm.php
@@ -26,20 +26,4 @@ class CreateForm extends CreateRecord
             LocaleSwitcher::make(),
         ];
     }
-
-    /**
-     * @throws Throwable
-     */
-    protected function afterValidate(): void
-    {
-        $formSections = $this->form->getComponent('sections')->getState();
-
-        foreach ($formSections as $sectionId => $section) {
-            foreach ($section['fields'] as $fieldId => $field) {
-                $this->mountAction('fields options', ['item' => $fieldId], ['schemaComponent' => "form.sections.$sectionId.fields"]);
-                $this->callMountedAction();
-                $this->unmountAction();
-            }
-        }
-    }
 }

--- a/src/Filament/Resources/FormResource/Pages/CreateForm.php
+++ b/src/Filament/Resources/FormResource/Pages/CreateForm.php
@@ -7,7 +7,6 @@ use LaraZeus\Bolt\BoltPlugin;
 use LaraZeus\Bolt\Filament\Resources\FormResource;
 use LaraZeus\SpatieTranslatable\Actions\LocaleSwitcher;
 use LaraZeus\SpatieTranslatable\Resources\Pages\CreateRecord\Concerns\Translatable;
-use Throwable;
 
 class CreateForm extends CreateRecord
 {

--- a/src/Filament/Resources/FormResource/Pages/EditForm.php
+++ b/src/Filament/Resources/FormResource/Pages/EditForm.php
@@ -10,7 +10,6 @@ use LaraZeus\Bolt\Filament\Resources\FormResource;
 use LaraZeus\Bolt\Models\Form;
 use LaraZeus\SpatieTranslatable\Actions\LocaleSwitcher;
 use LaraZeus\SpatieTranslatable\Resources\Pages\EditRecord\Concerns\Translatable;
-use Throwable;
 
 /**
  * @property Form $record.

--- a/src/Filament/Resources/FormResource/Pages/EditForm.php
+++ b/src/Filament/Resources/FormResource/Pages/EditForm.php
@@ -50,26 +50,4 @@ class EditForm extends EditRecord
                 ->openUrlInNewTab(),
         ];
     }
-
-    /**
-     * @throws Throwable
-     */
-    protected function afterValidate(): void
-    {
-        $formSections = $this->form->getComponent('sections')->getState();
-
-        foreach ($formSections as $sectionId => $section) {
-            foreach ($section['fields'] as $fieldId => $field) {
-                $context = ['schemaComponent' => "form.sections.$sectionId.fields"];
-
-                if (array_key_exists('id', $section)) {
-                    $context['recordKey'] = $section['id'];
-                }
-
-                $this->mountAction('fields options', ['item' => $fieldId], context: $context);
-                $this->callMountedAction();
-                $this->unmountAction();
-            }
-        }
-    }
 }


### PR DESCRIPTION
Fixes: #416 

The removed code was a workaround solution for https://github.com/lara-zeus/bolt/issues/378 .

It was working but it didn't follow filament docs, which lead to unexpected behaviour, when the internals of filament get upgraded.

Will have to find other solutions for https://github.com/lara-zeus/bolt/issues/378 .

