### PR TITLE
Dynamic / configurable default field type

### DIFF
--- a/src/Concerns/Schema/Fields.php
+++ b/src/Concerns/Schema/Fields.php
@@ -37,7 +37,7 @@ trait Fields
                     ->mapWithKeys(fn ($field) => [$field['class'] => static::getFieldsTypesOptions($field)])
                     ->toArray())
                 ->live()
-                ->default('\LaraZeus\Bolt\Fields\Classes\TextInput')
+                ->default(config('zeus-bolt.defaultFieldType') ?? Bolt::availableFields()->first()['class'])
                 ->label(__('zeus-bolt::forms.fields.type')),
 
             Hidden::make('description'),


### PR DESCRIPTION
Prevents the FQCN from appearing in the field type dropdown as the default by dynamically selecting the first option in the available list.

Also provides config for overriding the default type for when you want to make one of your overrides the default.